### PR TITLE
feat(ui): レスポンシブデザイン対応

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -34,7 +34,7 @@ export default function Main() {
 	const onReset = useResetAll();
 
 	return (
-		<Container maxW={"sm"} minW={"sm"} centerContent>
+		<Container w="100%" maxW="480px" mx="auto" p={0} centerContent pb="env(safe-area-inset-bottom)">
 			{settings.courtCount === 0 && <InitialSettingPane previousSettings={previousSettings} onStart={onStart} />}
 			{settings.courtCount !== 0 && <GamePane onReset={onReset} />}
 		</Container>

--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -3,7 +3,7 @@ import SharedPane from "./shared/SharedPane.tsx";
 
 export default function Share({ sharedId }: { sharedId: string }) {
 	return (
-		<Container maxW={"sm"} minW={"sm"}>
+		<Container w="100%" maxW="480px" mx="auto" pb="env(safe-area-inset-bottom)">
 			<SharedPane sharedId={sharedId} />
 		</Container>
 	);

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -34,7 +34,7 @@ export default function ConfirmDialog({
 		>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content maxW={"350px"}>
+				<Dialog.Content maxW={"90dvw"}>
 					<Dialog.Header fontSize="lg" fontWeight="bold" {...prettyFont}>
 						{title}
 					</Dialog.Header>

--- a/src/components/common/HistoryDialog.tsx
+++ b/src/components/common/HistoryDialog.tsx
@@ -9,17 +9,17 @@ type Props = {
 
 export function HistoryDialog({ open, onClose }: Props) {
 	return (
-		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} scrollBehavior={"inside"}>
+		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} scrollBehavior={"inside"} size={"full"}>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content maxW={"350px"}>
+				<Dialog.Content w="100%">
 					<Dialog.Header maxH={"xs"} style={{ ...prettyFont }}>
 						履歴
 					</Dialog.Header>
 					<Dialog.CloseTrigger asChild>
 						<CloseButton size="sm" />
 					</Dialog.CloseTrigger>
-					<Dialog.Body py={4} px={0}>
+					<Dialog.Body p={4}>
 						<Center>
 							<HistoryPane />
 						</Center>

--- a/src/components/common/HistoryPane.tsx
+++ b/src/components/common/HistoryPane.tsx
@@ -68,7 +68,7 @@ export default function HistoryPane(props: { histories?: History[] }) {
 	);
 
 	return (
-		<Stack gap={3} separator={<Separator />}>
+		<Stack gap={3} separator={<Separator />} w={"100%"}>
 			{current && <CurrentHistoryPane {...current.history} />}
 			{previous && <PreviousHistoryPane {...previous.history} />}
 			{olds &&

--- a/src/components/common/MemberDialog.tsx
+++ b/src/components/common/MemberDialog.tsx
@@ -12,10 +12,10 @@ type Props = {
 
 export function MemberDialog({ settings, defaultTabIndex, open, onClose, showLeftMember }: Props) {
 	return (
-		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} placement="center">
+		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} size={"full"}>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content maxW={"350px"}>
+				<Dialog.Content w="100%">
 					<Dialog.Header>
 						<Heading as={"label"} size={"sm"}>
 							プレイ回数・休憩回数

--- a/src/components/game/CourtMembersPane.tsx
+++ b/src/components/game/CourtMembersPane.tsx
@@ -8,10 +8,10 @@ type ParentProps = {
 	archive?: boolean;
 };
 
-export default function CourtMembersPane({ members, single = true, archive = false }: ParentProps) {
+export default function CourtMembersPane({ members, single = false, archive = false }: ParentProps) {
 	const courtIds = array.generate(members.length, 0);
 	return (
-		<SimpleGrid columns={single ? 1 : 2} gap={4} justifyItems={"center"}>
+		<SimpleGrid columns={2} gap={4} justifyItems={"center"}>
 			{members.length > 0 &&
 				courtIds.map((id) => <CourtCard key={id} id={id} members={members[id]} single={single} archive={archive} />)}
 		</SimpleGrid>
@@ -25,27 +25,23 @@ type ChildProps = {
 	archive?: boolean;
 };
 
-function CourtCard({ id, members, single, archive }: ChildProps) {
-	const w = single ? "300px" : "150px";
-	const s = single ? 12 : 4;
+function CourtCard({ id, members, archive }: ChildProps) {
 	const headColor = archive ? "gray.500" : "gray.600";
 	const color = archive ? "gray.500" : "primary.900";
 
 	return (
-		<Card.Root p={2} maxW={w} minW={w}>
-			<Center>
-				<Stack>
-					<Center>
-						<Heading as={"label"} size={"sm"} color={headColor}>{`コート${id + 1}`}</Heading>
-					</Center>
-					<Separator />
-					<HStack gap={s} color={color}>
-						{members.map((member) => (
-							<strong key={member}>{member}</strong>
-						))}
-					</HStack>
-				</Stack>
-			</Center>
+		<Card.Root p={2} w="100%">
+			<Stack w={"100%"}>
+				<Center>
+					<Heading as={"label"} size={"sm"} color={headColor}>{`コート${id + 1}`}</Heading>
+				</Center>
+				<Separator />
+				<HStack w="100%" justify="space-evenly" color={color}>
+					{members.map((member) => (
+						<strong key={member}>{member}</strong>
+					))}
+				</HStack>
+			</Stack>
 		</Card.Root>
 	);
 }

--- a/src/components/game/CurrentMemberCountInput.test.tsx
+++ b/src/components/game/CurrentMemberCountInput.test.tsx
@@ -79,7 +79,7 @@ describe("CurrentMemberCountInput", () => {
 
 			// LeaveDialog が表示される（番号選択のセレクトボックス）
 			await waitFor(() => {
-				expect(screen.getByText("番号を選択してください")).toBeInTheDocument();
+				expect(screen.getByText("離脱する番号")).toBeInTheDocument();
 			});
 		});
 

--- a/src/components/game/CurrentMemberCountInput.tsx
+++ b/src/components/game/CurrentMemberCountInput.tsx
@@ -1,4 +1,4 @@
-import { Button, HStack, Input, Spacer, useDisclosure } from "@chakra-ui/react";
+import { Button, HStack, Input, Spacer, Text, useDisclosure } from "@chakra-ui/react";
 import { TbUserOff, TbUserPlus } from "react-icons/tb";
 import { COURT_CAPACITY, MEMBER_COUNT_LIMIT } from "@logic";
 import { LeaveDialog } from "@components/game/LeaveDialog";
@@ -16,8 +16,8 @@ export function CurrentMemberCountInput({ onIncrement, onDecrement, disabled }: 
 	const { open, onOpen, onClose } = useDisclosure();
 
 	return (
-		<HStack maxW={"320px"} minW={"320px"}>
-			<span>現在</span>
+		<HStack w={"100%"}>
+			<Text fontSize={"sm"}>現在</Text>
 			<Input
 				type={"number"}
 				value={members.length}
@@ -31,7 +31,7 @@ export function CurrentMemberCountInput({ onIncrement, onDecrement, disabled }: 
 				borderBottom="none"
 				readOnly
 			/>
-			<span>人</span>
+			<Text fontSize={"sm"}>人</Text>
 			<Spacer />
 			<Button
 				size={"xs"}

--- a/src/components/game/GamePane.tsx
+++ b/src/components/game/GamePane.tsx
@@ -75,10 +75,10 @@ export default function GamePane({ onReset }: Props) {
 	};
 
 	return (
-		<Card.Root m={0} p={0} height={"100dvh"}>
-			<Card.Body px={4} pt={2}>
+		<Card.Root w={"100%"} height={"100dvh"} borderWidth={0} boxShadow={"none"}>
+			<Card.Body px={4} py={2}>
 				<Center>
-					<Stack gap={2}>
+					<Stack gap={2} w={"100%"}>
 						<CurrentMemberCountInput onIncrement={handleJoin} onDecrement={handleLeave} disabled={progress} />
 						<Center>
 							<AlgorithmBadge algorithm={settings.algorithm} />
@@ -98,7 +98,7 @@ export default function GamePane({ onReset }: Props) {
 				</Center>
 			</Card.Body>
 			<Separator color={"gray.300"} />
-			<Card.Footer px={10} py={2}>
+			<Card.Footer px={8} py={2} pb="max(8px, env(safe-area-inset-bottom))">
 				<HistoryButton disabled={progress} />
 				<Spacer />
 				<MemberButton disabled={progress} />

--- a/src/components/game/GenerateButton.tsx
+++ b/src/components/game/GenerateButton.tsx
@@ -55,9 +55,9 @@ export function GenerateButton({ settings, onGenerate, disabled, onIgnoreUsageAl
 			<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} size={"full"}>
 				<Dialog.Backdrop />
 				<Dialog.Positioner>
-					<Dialog.Content maxW={"350px"}>
+					<Dialog.Content>
 						<Dialog.Header>
-							<Stack gap={3}>
+							<Stack gap={3} w={"100%"}>
 								<Heading as={"h3"} size={"md"}>
 									メンバー選出
 								</Heading>

--- a/src/components/game/LeaveDialog.tsx
+++ b/src/components/game/LeaveDialog.tsx
@@ -24,11 +24,11 @@ export function LeaveDialog({ members, open, onClose, onLeave }: Props) {
 		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} size={"xs"}>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content>
+				<Dialog.Content maxW={"80dvw"}>
 					<Dialog.Body py={4}>
 						<HStack>
 							<NativeSelect.Root>
-								<NativeSelect.Field placeholder="番号を選択してください" onChange={handleSelect}>
+								<NativeSelect.Field placeholder="離脱する番号" onChange={handleSelect}>
 									{members.map((id) => (
 										<option key={id} value={id}>
 											{id}

--- a/src/components/game/ShareDialog.tsx
+++ b/src/components/game/ShareDialog.tsx
@@ -26,7 +26,7 @@ export function ShareDialog({ open, onClose, value }: Props) {
 		<Dialog.Root open={open} onOpenChange={(e) => !e.open && onClose()} scrollBehavior={"inside"}>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content maxW={"350px"}>
+				<Dialog.Content maxW={"90dvw"}>
 					<Dialog.Header maxH={"xs"}>
 						<Heading as={"label"} size={"md"}>
 							リアルタイム共有
@@ -42,7 +42,7 @@ export function ShareDialog({ open, onClose, value }: Props) {
 								<Center>
 									<LineShareButton url={value} />
 									<Spacer />
-									<Button size={"sm"} w={"8rem"} onClick={handleCopy}>
+									<Button size={"xs"} w={"7rem"} onClick={handleCopy}>
 										<MdContentCopy />
 										URLコピー
 									</Button>

--- a/src/components/game/StatisticsPane.tsx
+++ b/src/components/game/StatisticsPane.tsx
@@ -24,7 +24,7 @@ export function StatisticsPane({ settings, onAdjusted }: Props) {
 	};
 
 	return (
-		<Stack gap={3}>
+		<Stack gap={3} w={"100%"} px={4}>
 			<HistoryPane histories={histories} />
 			{showStatistics && (
 				<Center mt={4}>

--- a/src/components/game/adjustment/AdjustmentDialog.tsx
+++ b/src/components/game/adjustment/AdjustmentDialog.tsx
@@ -41,7 +41,7 @@ export function AdjustmentDialog({ settings, open, onClose, onChange }: Props) {
 		>
 			<Dialog.Backdrop />
 			<Dialog.Positioner>
-				<Dialog.Content maxW={"350px"} maxH={"100dvh"}>
+				<Dialog.Content w="100%" maxH={"100dvh"}>
 					<Dialog.Header>
 						<Stack gap={3}>
 							<Heading as={"h3"} size={"md"}>

--- a/src/components/setting/InitMemberCountInput.tsx
+++ b/src/components/setting/InitMemberCountInput.tsx
@@ -12,7 +12,7 @@ type Props = {
 export function InitMemberCountInput({ min, value, onChange }: Props) {
 	return (
 		<VStack gap={4}>
-			<HStack maxW={"320px"} minW={"320px"}>
+			<HStack w={"100%"}>
 				<IconButton
 					colorPalette={"brand"}
 					aria-label="decrement"
@@ -53,7 +53,7 @@ export function InitMemberCountInput({ min, value, onChange }: Props) {
 				max={MEMBER_COUNT_LIMIT}
 				value={[value]}
 				onValueChange={(details) => onChange(Math.max(min, details.value[0]))}
-				width={"320px"}
+				w={"100%"}
 			>
 				<Slider.Control>
 					<Slider.Track>

--- a/src/components/setting/InitialSettingPane.tsx
+++ b/src/components/setting/InitialSettingPane.tsx
@@ -46,10 +46,10 @@ export default function InitialSettingPane({ previousSettings, onStart }: Props)
 	};
 
 	return (
-		<Card.Root m={0} p={0} height={"100dvh"}>
-			<Card.Body px={4} pt={6}>
+		<Card.Root w="100%" height={"100dvh"} borderWidth={0} boxShadow="none">
+			<Card.Body p={6}>
 				<Center>
-					<Stack gap={5}>
+					<Stack gap={5} w="100%">
 						<HStack>
 							<Image src={logo} boxSize="24px" borderRadius={"md"} />
 							<Heading as="h1" size="sm">

--- a/src/components/shared/SharedPane.tsx
+++ b/src/components/shared/SharedPane.tsx
@@ -112,7 +112,7 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 	}, [event, dispatch]);
 
 	return (
-		<Card.Root my={1} py={4}>
+		<Card.Root w="100%" my={1} py={4} borderWidth={0} boxShadow="none">
 			{finished && (
 				<Alert.Root status="error" mb={2}>
 					<Alert.Indicator />


### PR DESCRIPTION
- コンテナとカードの固定幅を解除し、画面幅100%に変更
- ダイアログの幅を動的サイズ（90dvw または 100%）に変更
- 入力コンポーネントの幅を動的サイズに変更
- コートカードのメンバー番号を均等配置（space-evenly）に変更
- セーフエリア対応（safe-area-inset-bottom）を追加
- カード枠線を削除（borderWidth=0, boxShadow=none）