### PR TITLE
feat: /share/:id で存在しない ID の場合にエラー表示を追加

### DIFF
--- a/src/api/environment.test.ts
+++ b/src/api/environment.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // vi.hoisted でモック関数を先に作成
-const { mockCreate, mockUpdate } = vi.hoisted(() => ({
+const { mockCreate, mockUpdate, mockGet } = vi.hoisted(() => ({
 	mockCreate: vi.fn(),
 	mockUpdate: vi.fn(),
+	mockGet: vi.fn(),
 }));
 
 // client モジュールのモック
@@ -13,13 +14,14 @@ vi.mock("./client", () => ({
 			Environment: {
 				create: mockCreate,
 				update: mockUpdate,
+				get: mockGet,
 			},
 		},
 	},
 }));
 
 // テスト対象のインポートはモック設定後に行う
-import { createEnvironment, finishEnvironment } from "./environment";
+import { createEnvironment, finishEnvironment, getEnvironment } from "./environment";
 
 describe("environment", () => {
 	beforeEach(() => {
@@ -73,6 +75,27 @@ describe("environment", () => {
 				id: envId,
 				finishedAt: now.toISOString(),
 			});
+		});
+	});
+
+	describe("getEnvironment", () => {
+		it("should return environment when it exists", async () => {
+			const envId = "existing-env-id";
+			mockGet.mockResolvedValue({ data: { id: envId } });
+
+			const result = await getEnvironment(envId);
+
+			expect(result).toEqual({ id: envId });
+			expect(mockGet).toHaveBeenCalledWith({ id: envId });
+		});
+
+		it("should return null when environment does not exist", async () => {
+			mockGet.mockResolvedValue({ data: null });
+
+			const result = await getEnvironment("non-existent-id");
+
+			expect(result).toBeNull();
+			expect(mockGet).toHaveBeenCalledWith({ id: "non-existent-id" });
 		});
 	});
 });

--- a/src/api/environment.ts
+++ b/src/api/environment.ts
@@ -17,3 +17,8 @@ export async function finishEnvironment(id: string): Promise<void> {
 		finishedAt: new Date().toISOString(),
 	});
 }
+
+export async function getEnvironment(id: string): Promise<{ id: string } | null> {
+	const { data } = await client.models.Environment.get({ id });
+	return data ? { id: data.id } : null;
+}

--- a/src/components/Share.test.tsx
+++ b/src/components/Share.test.tsx
@@ -11,6 +11,7 @@ vi.mock("../api", async () => {
 		...actual,
 		findAllEvents: vi.fn(),
 		subscribeEvent: vi.fn(() => ({ unsubscribe: vi.fn() })),
+		getEnvironment: vi.fn(),
 	};
 });
 

--- a/src/components/shared/SharedPane.test.tsx
+++ b/src/components/shared/SharedPane.test.tsx
@@ -22,6 +22,7 @@ vi.mock("../../api", async () => {
 		...actual,
 		findAllEvents: vi.fn(),
 		subscribeEvent: vi.fn(() => ({ unsubscribe: vi.fn() })),
+		getEnvironment: vi.fn(),
 	};
 });
 
@@ -49,34 +50,40 @@ describe("SharedPane", () => {
 	});
 
 	describe("useRealtimeSync フックの統合（Task 2.1）", () => {
-		it("useRealtimeSync フックが sharedId とコールバックで呼び出される", () => {
+		it("useRealtimeSync フックが sharedId とコールバックで呼び出される", async () => {
 			setupMockWithEvents([]);
 
 			render(<SharedPane sharedId="test-shared-id" />);
 
-			expect(mockUseRealtimeSync).toHaveBeenCalledWith({
-				sharedId: "test-shared-id",
-				onEvent: expect.any(Function),
-				onSync: expect.any(Function),
+			await waitFor(() => {
+				expect(mockUseRealtimeSync).toHaveBeenCalledWith({
+					sharedId: "test-shared-id",
+					onEvent: expect.any(Function),
+					onSync: expect.any(Function),
+				});
 			});
 		});
 
-		it("subscribed state は使用されず、フック内部で管理される", () => {
+		it("subscribed state は使用されず、フック内部で管理される", async () => {
 			setupMockWithEvents([]);
 
 			render(<SharedPane sharedId="test-id" />);
 
 			// subscribeEvent が直接呼ばれないことを確認（フック経由のみ）
-			expect(api.subscribeEvent).not.toHaveBeenCalled();
+			await waitFor(() => {
+				expect(api.subscribeEvent).not.toHaveBeenCalled();
+			});
 		});
 
-		it("findAllEvents が直接呼ばれないことを確認（フック経由のみ）", () => {
+		it("findAllEvents が直接呼ばれないことを確認（フック経由のみ）", async () => {
 			setupMockWithEvents([]);
 
 			render(<SharedPane sharedId="test-id" />);
 
 			// findAllEvents が直接呼ばれないことを確認
-			expect(api.findAllEvents).not.toHaveBeenCalled();
+			await waitFor(() => {
+				expect(api.findAllEvents).not.toHaveBeenCalled();
+			});
 		});
 	});
 
@@ -408,6 +415,53 @@ describe("SharedPane", () => {
 
 			await waitFor(() => {
 				expect(screen.getByText(/今回/)).toBeInTheDocument();
+			});
+		});
+	});
+
+	describe("存在しない ID", () => {
+		it("存在しない ID の場合、エラー状態の Alert が表示される", async () => {
+			// getEnvironment が null を返すようモック
+			vi.mocked(api.getEnvironment).mockResolvedValue(null);
+
+			let called = false;
+			mockUseRealtimeSync.mockImplementation((options) => {
+				if (!called) {
+					called = true;
+					Promise.resolve().then(() => {
+						options.onSync([]);
+					});
+				}
+				return { sync: vi.fn() };
+			});
+
+			render(<SharedPane sharedId="non-existent-id" />);
+
+			await waitFor(() => {
+				expect(screen.getByTestId("not-found-alert")).toBeInTheDocument();
+			});
+		});
+
+		it("環境は存在するがイベントが空の場合、Alert は表示されない", async () => {
+			// getEnvironment が環境を返すようモック
+			vi.mocked(api.getEnvironment).mockResolvedValue({ id: "existing-env" });
+
+			let called = false;
+			mockUseRealtimeSync.mockImplementation((options) => {
+				if (!called) {
+					called = true;
+					Promise.resolve().then(() => {
+						options.onSync([]);
+					});
+				}
+				return { sync: vi.fn() };
+			});
+
+			render(<SharedPane sharedId="existing-env" />);
+
+			// 少し待ってから Alert がないことを確認
+			await waitFor(() => {
+				expect(screen.queryByTestId("not-found-alert")).not.toBeInTheDocument();
 			});
 		});
 	});

--- a/src/components/shared/SharedPane.tsx
+++ b/src/components/shared/SharedPane.tsx
@@ -3,7 +3,7 @@ import { atom } from "jotai";
 import { useCallback, useState } from "react";
 import { MdHome, MdRefresh } from "react-icons/md";
 import { match } from "ts-pattern";
-import { type Event, EventType, replayEvent } from "../../api";
+import { type Event, EventType, getEnvironment, replayEvent } from "../../api";
 import { useRealtimeSync } from "../../hooks";
 import type { CurrentSettings } from "../../logic";
 import { AlgorithmBadge } from "../common/AlgorithmBadge.tsx";
@@ -48,6 +48,7 @@ function getMessageStatus(type: EventType): "success" | "warning" | "info" | "er
 export default function SharedPane({ sharedId }: { sharedId: string }) {
 	const [settings, dispatch] = useReducerAtom(settingsAtom, settingsReducer);
 	const [finished, setFinished] = useState(false);
+	const [notFound, setNotFound] = useState(false);
 
 	// onEvent: 個別イベント受信時のコールバック
 	const handleEvent = useCallback(
@@ -76,15 +77,20 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 
 	// onSync: 全イベント取得後のコールバック（初期化・復帰時）
 	const handleSync = useCallback(
-		(events: Event[]) => {
+		async (events: Event[]) => {
+			// イベントが空の場合、Environment の存在確認を行う
 			if (events.length === 0) {
+				const env = await getEnvironment(sharedId);
+				if (!env) {
+					setNotFound(true);
+				}
 				return;
 			}
 			const { settings, finished } = replayEvents(events);
 			dispatch({ type: EventType.Initialize, payload: settings });
 			setFinished(finished);
 		},
-		[dispatch],
+		[dispatch, sharedId],
 	);
 
 	// useRealtimeSync フックを使用してライフサイクル管理を委譲
@@ -93,6 +99,20 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 		onEvent: handleEvent,
 		onSync: handleSync,
 	});
+
+	if (notFound) {
+		return (
+			<Card.Root w="100%" my={1} py={4} borderWidth={0} boxShadow="none">
+				<Alert.Root status="error" data-testid="not-found-alert">
+					<Alert.Indicator />
+					<Alert.Content>
+						<Alert.Title>共有されたイベントが見つかりません</Alert.Title>
+						<Alert.Description>終了から一定期間経過すると自動で削除されます。</Alert.Description>
+					</Alert.Content>
+				</Alert.Root>
+			</Card.Root>
+		);
+	}
 
 	return (
 		<Card.Root w="100%" my={1} py={4} borderWidth={0} boxShadow="none">


### PR DESCRIPTION
- getEnvironment(id) 関数を追加し、Environment の存在確認を実装
- SharedPane で空イベント時に Environment 存在確認を行い、 Environment が存在しない場合はエラーを表示