### PR TITLE
fix: Lambda バンドル時の amplify_outputs.json 依存エラーを修正

### DIFF
--- a/amplify/functions/pushNotifier/handler.ts
+++ b/amplify/functions/pushNotifier/handler.ts
@@ -3,8 +3,7 @@ import { DeleteCommand, DynamoDBDocumentClient, QueryCommand } from "@aws-sdk/li
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 import type { DynamoDBRecord, DynamoDBStreamHandler } from "aws-lambda";
 import webpush from "web-push";
-import { type EventPayload, type EventType, EventType as EventTypes } from "../../../src/api/event";
-import type { PushPayload } from "../../../src/sw";
+import { type EventPayload, type EventType, EventType as EventTypes, type PushPayload } from "../../../src/api/types";
 import type { Schema } from "../../data/resource";
 import { setupVapidDetails } from "./setup";
 

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -1,61 +1,9 @@
 import { match } from "ts-pattern";
 import { type CurrentSettings, type GameMembers, join, leave, replayGenerate, replayRetry } from "../logic";
 import { client, type Schema } from "./client";
+import { type Event, type EventPayload, EventType, type InitializeEventPayload } from "./types";
 
-export const EventType = {
-	Initialize: "INITIALIZE",
-	Join: "JOIN",
-	Leave: "LEAVE",
-	Generate: "GENERATE",
-	Retry: "RETRY",
-	Finish: "FINISH",
-} as const;
-
-export type EventType = (typeof EventType)[keyof typeof EventType];
-
-type InitializeEventPayload = {
-	type: typeof EventType.Initialize;
-	payload: CurrentSettings;
-};
-
-type JoinEventPayload = {
-	type: typeof EventType.Join;
-	payload?: never;
-};
-
-type LeaveEventPayload = {
-	type: typeof EventType.Leave;
-	payload: { memberId: number };
-};
-
-type GenerateEventPayload = {
-	type: typeof EventType.Generate;
-	payload: { members: GameMembers };
-};
-
-type RetryEventPayload = {
-	type: typeof EventType.Retry;
-	payload: { members: GameMembers };
-};
-
-type FinishEventPayload = {
-	type: typeof EventType.Finish;
-	payload?: never;
-};
-
-export type EventPayload = (
-	| InitializeEventPayload
-	| JoinEventPayload
-	| LeaveEventPayload
-	| GenerateEventPayload
-	| RetryEventPayload
-	| FinishEventPayload
-) & { silent?: boolean };
-
-export type Event = EventPayload & {
-	id: string;
-	occurredAt: Date;
-};
+export { EventType, type EventPayload, type Event, type InitializeEventPayload };
 
 type EventModel = Schema["Event"]["type"];
 

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,69 @@
+/**
+ * Lambda とフロントエンドで共有する型定義
+ * client.ts (amplify_outputs.json) への依存を避けるため、ここに切り出す
+ */
+
+import type { CurrentSettings, GameMembers } from "../logic";
+
+export const EventType = {
+	Initialize: "INITIALIZE",
+	Join: "JOIN",
+	Leave: "LEAVE",
+	Generate: "GENERATE",
+	Retry: "RETRY",
+	Finish: "FINISH",
+} as const;
+
+export type EventType = (typeof EventType)[keyof typeof EventType];
+
+export type InitializeEventPayload = {
+	type: typeof EventType.Initialize;
+	payload: CurrentSettings;
+};
+
+export type JoinEventPayload = {
+	type: typeof EventType.Join;
+	payload?: never;
+};
+
+export type LeaveEventPayload = {
+	type: typeof EventType.Leave;
+	payload: { memberId: number };
+};
+
+export type GenerateEventPayload = {
+	type: typeof EventType.Generate;
+	payload: { members: GameMembers };
+};
+
+export type RetryEventPayload = {
+	type: typeof EventType.Retry;
+	payload: { members: GameMembers };
+};
+
+export type FinishEventPayload = {
+	type: typeof EventType.Finish;
+	payload?: never;
+};
+
+export type EventPayload = (
+	| InitializeEventPayload
+	| JoinEventPayload
+	| LeaveEventPayload
+	| GenerateEventPayload
+	| RetryEventPayload
+	| FinishEventPayload
+) & { silent?: boolean };
+
+export type Event = EventPayload & {
+	id: string;
+	occurredAt: Date;
+};
+
+export type PushPayload = {
+	title: string;
+	body: string;
+	icon: string;
+	tag: string;
+	data: { url: string };
+};

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,15 +1,8 @@
 /// <reference lib="webworker" />
 
-declare const self: ServiceWorkerGlobalScope;
+import type { PushPayload } from "./api/types";
 
-// amplify/functions/pushNotifier から参照するため export
-export type PushPayload = {
-	title: string;
-	body: string;
-	icon: string;
-	tag: string;
-	data: { url: string };
-};
+declare const self: ServiceWorkerGlobalScope;
 
 function isServiceWorkerScope(value: unknown): value is ServiceWorkerGlobalScope {
 	return typeof value === "object" && value !== null && "clients" in value && "registration" in value;


### PR DESCRIPTION
pushNotifier Lambda が src/api/event.ts → src/api/client.ts → amplify_outputs.json の依存チェーンを辿り、ビルド時に存在しない
ファイルを参照してデプロイエラーが発生していた問題を修正。

- src/api/types.ts を新規作成し、共有型定義を集約
- Lambda とフロントエンドで client.ts に依存せず型のみ参照可能に
- EventType, EventPayload, PushPayload 等の型を types.ts に移動