### PR TITLE
fix: 共有画面で初期化前にフォールバック値が表示される問題を修正

### DIFF
--- a/src/components/Share.test.tsx
+++ b/src/components/Share.test.tsx
@@ -22,8 +22,22 @@ describe("Share", () => {
 
 	describe("基本表示", () => {
 		it("sharedIdが渡されるとSharedPaneが表示される", async () => {
-			// 空のイベントを返す
-			vi.mocked(api.findAllEvents).mockResolvedValue([]);
+			// 初期化イベントを返す
+			const mockEvents: api.Event[] = [
+				{
+					id: "event-1",
+					type: api.EventType.Initialize,
+					occurredAt: new Date(),
+					payload: {
+						courtCount: 2,
+						members: [1, 2, 3, 4],
+						histories: [],
+						gameCounts: {},
+						algorithm: Algorithms.DISCRETENESS,
+					},
+				},
+			];
+			vi.mocked(api.findAllEvents).mockResolvedValue(mockEvents);
 
 			render(<Share sharedId="test-share-id" />);
 

--- a/src/components/shared/SharedPane.test.tsx
+++ b/src/components/shared/SharedPane.test.tsx
@@ -268,13 +268,40 @@ describe("SharedPane", () => {
 
 	describe("基本表示", () => {
 		it("参加者数が表示される", async () => {
-			setupMockWithEvents([]);
+			const mockEvents: api.Event[] = [
+				{
+					id: "event-1",
+					type: api.EventType.Initialize,
+					occurredAt: new Date(),
+					payload: {
+						courtCount: 2,
+						members: [1, 2, 3, 4],
+						histories: [],
+						gameCounts: {},
+						algorithm: Algorithms.DISCRETENESS,
+					},
+				},
+			];
+
+			setupMockWithEvents(mockEvents);
 
 			render(<SharedPane sharedId="test-id" />);
 
 			await waitFor(() => {
 				expect(screen.getByText(/人が参加/)).toBeInTheDocument();
 			});
+		});
+
+		it("初期化前はローディング表示される", async () => {
+			// onSync を呼ばないようにして、初期化前の状態を維持
+			mockUseRealtimeSync.mockImplementation(() => {
+				return { sync: vi.fn() };
+			});
+
+			render(<SharedPane sharedId="test-id" />);
+
+			// ローディング中は Spinner が表示され、参加者数は表示されない
+			expect(screen.queryByText(/人が参加/)).not.toBeInTheDocument();
 		});
 	});
 

--- a/src/components/shared/SharedPane.tsx
+++ b/src/components/shared/SharedPane.tsx
@@ -1,4 +1,4 @@
-import { Alert, Card, Center, Heading, HStack, IconButton, Link, Spacer } from "@chakra-ui/react";
+import { Alert, Card, Center, Heading, HStack, IconButton, Link, Spacer, Spinner } from "@chakra-ui/react";
 import { atom } from "jotai";
 import { useCallback, useState } from "react";
 import { MdHome, MdRefresh } from "react-icons/md";
@@ -50,6 +50,7 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 	const [settings, dispatch] = useReducerAtom(settingsAtom, settingsReducer);
 	const [finished, setFinished] = useState(false);
 	const [notFound, setNotFound] = useState(false);
+	const [initialized, setInitialized] = useState(false);
 	const [bannerDismissed, setBannerDismissed] = useState(false);
 
 	// プッシュ通知購読フック
@@ -91,11 +92,13 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 				if (!env) {
 					setNotFound(true);
 				}
+				setInitialized(true);
 				return;
 			}
 			const { settings, finished } = replayEvents(events);
 			dispatch({ type: EventType.Initialize, payload: settings });
 			setFinished(finished);
+			setInitialized(true);
 		},
 		[dispatch, sharedId],
 	);
@@ -117,6 +120,16 @@ export default function SharedPane({ sharedId }: { sharedId: string }) {
 						<Alert.Description>終了から一定期間経過すると自動で削除されます。</Alert.Description>
 					</Alert.Content>
 				</Alert.Root>
+			</Card.Root>
+		);
+	}
+
+	if (!initialized) {
+		return (
+			<Card.Root w="100%" my={1} py={4} borderWidth={0} boxShadow="none">
+				<Center py={8}>
+					<Spinner size="lg" color="brand.500" />
+				</Center>
 			</Card.Root>
 		);
 	}


### PR DESCRIPTION
共有画面を開いた際、イベント取得完了前に「0 人が参加中」と
「ばらつき重視」が表示される問題を修正。

- initialized state を追加し、イベント取得完了前はローディング画面を表示
- Spinner のスタイルを ConfirmDialog と統一 (size="lg", color="brand.500")
- テストを修正し、ローディング状態のテストを追加

Closes #64