### PR TITLE
Renovate DEBUG ログを有効化（PR未作成問題の調査）

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          LOG_LEVEL: info
+          LOG_LEVEL: debug
           RENOVATE_REPOSITORIES: ${{ github.repository }}
 
   validate:


### PR DESCRIPTION
## 問題の概要
patch/minor 更新でブランチは作成されるが PR が作成されない。
major 更新の PR は正常に作成される。

## 時系列

### 設定変更（本ブランチ）
1. renovate.json → renovate.json5 に移行（コメント追加のため）
2. サプライチェーン攻撃対策として以下を追加:
   - minimumReleaseAge: "7 days"（新規リリースから7日間の猶予期間）
   - internalChecksFilter: "strict"（猶予期間中はブランチ/PRを作成しない）
3. patch/minor 更新に prCreation: "status-success" を追加
   - 目的: CI が失敗する PR を作成しない（ノイズ削減）
4. major 更新には prCreation 設定なし（デフォルト: immediate）

### Renovate 実行（1回目）2026-01-31 18:18 UTC
- renovate/develop-devdependencies ブランチ作成 → PR 作成されず
- renovate/develop-npm-run-all2-8.x ブランチ作成 → PR 作成された
- reviewers 設定で 422 エラー発生（PR作成者に自分をレビュアー指定できない）
  - "Review cannot be requested from pull request author."

### ユーザー操作
- npm-run-all2-8.x の PR をマージ

### Renovate 実行（2回目）2026-01-31 18:28 UTC
- renovate/develop-devdependencies ブランチ更新 → PR まだ作成されず
- renovate/main-devdependencies ブランチ更新 → PR 作成されず
- renovate/develop-npm-run-all2-8.x を orphan として削除（マージ済み）

### 確認事項
- GitHub Actions CI は renovate/develop-devdependencies ブランチで成功している
- ci.yml は push イベントで branches-ignore: [develop, main] なので renovate ブランチで実行される

## 観察された事実
| ブランチ | updateType | prCreation 設定 | PR 作成 |
|---------|-----------|----------------|--------|
| npm-run-all2-8.x | major | なし (immediate) | ✅ |
| devdependencies | patch/minor | status-success | ❌ |

## 調査で判明したこと

### prCreation: "status-success" の動作
- ブランチ作成後、すべてのステータスチェックが成功したら PR を作成
- 参考: https://docs.renovatebot.com/faq/

### minimumReleaseAge の動作
- renovate/stability-days という内部ステータスチェックをブランチに追加
- internalChecksFilter: "strict" と組み合わせると、猶予期間中はブランチを作成しない
- 参考: https://docs.renovatebot.com/key-concepts/minimum-release-age/

### 既知の問題・議論

1. prCreation: "status-success" と minimumReleaseAge の組み合わせ問題
   - renovate/stability-days のステータス更新と評価のタイミング問題
   - 同一実行内で更新しても "pending" と評価される可能性
   - 参考: https://github.com/renovatebot/renovate/discussions/15764

2. "Branch is X hours old - skipping PR creation" 問題
   - prNotPendingHours によるタイムアウト
   - 参考: https://github.com/renovatebot/renovate/discussions/16050
   - 参考: https://github.com/renovatebot/renovate/discussions/14724

3. renovate/stability-days ステータスチェックの問題
   - internalChecksFilter: "strict" 使用時に無効化したいという要望
   - 参考: https://github.com/renovatebot/renovate/discussions/28283

4. Renovate 42.19.9 以降のドキュメント変更
   - prCreation の設定は推奨されなくなった
   - internalChecksFilter: "strict" のみ使用し、prCreation はデフォルトのまま推奨
   - 参考: https://docs.renovatebot.com/key-concepts/minimum-release-age/

### GitHub Copilot の見解（未検証）
- internalChecksFilter: "strict" により prCreation: "status-success" と minimumReleaseAge の併用が可能になる
- 内部チェックとの競合を回避できる
- ただし、実際には PR が作成されなかった事実と矛盾

## 未確定事項
- 真の原因は特定できていない
- prCreation: "status-success" が原因である可能性は高いが、状況証拠のみ
- minimumReleaseAge との組み合わせ問題か、単体の問題かは不明

## 本コミットの目的
DEBUG ログで以下を確認する:
- "Branch status" 関連のメッセージ
- "skipping PR creation" 等の PR 作成スキップ理由
- renovate/stability-days ステータスチェックの状態
- prCreation 評価時のステータス一覧

## 変更内容
- LOG_LEVEL: info → debug