### PR TITLE
prCreation: "status-success" を無効化（PR未作成問題の解決）

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.RENOVATE_TOKEN }}
         env:
-          LOG_LEVEL: debug
+          LOG_LEVEL: info
           RENOVATE_REPOSITORIES: ${{ github.repository }}
 
   validate:

--- a/renovate.json5
+++ b/renovate.json5
@@ -24,33 +24,33 @@
 		"enabled": false
 	},
 
+	// prCreation: "status-success" は無効化
+	// 理由: Renovate実行中にCIが完了せず常にpendingと評価されPRが作成されないため
+
 	"packageRules": [
-		// dependencies (patch/minor): CI通過後にPR作成・自動マージ
+		// dependencies (patch/minor): 自動マージ
 		{
 			"description": "Group all dependencies patch/minor updates",
 			"matchDepTypes": ["dependencies"],
 			"matchUpdateTypes": ["patch", "minor"],
 			"groupName": "dependencies",
-			"prCreation": "status-success",
 			"automerge": true,
 			"automergeType": "pr",
 			"automergeStrategy": "squash",
 			"labels": ["renovate", "automerge"]
 		},
-		// devDependencies (patch/minor): CI通過後にPR作成・自動マージ
+		// devDependencies (patch/minor): 自動マージ
 		{
 			"description": "Group all devDependencies patch/minor updates",
 			"matchDepTypes": ["devDependencies"],
 			"matchUpdateTypes": ["patch", "minor"],
 			"groupName": "devDependencies",
-			"prCreation": "status-success",
 			"automerge": true,
 			"automergeType": "pr",
 			"automergeStrategy": "squash",
 			"labels": ["renovate", "automerge"]
 		},
 		// メジャー更新: 破壊的変更のためレビュー必須
-		// prCreation: "status-success" は使用しない（CIが失敗しても更新の存在を把握したいため）
 		{
 			"description": "Major updates require review",
 			"matchUpdateTypes": ["major"],


### PR DESCRIPTION
## 問題
patch/minor 更新でブランチは作成されるが PR が作成されない。

## 根本原因（DEBUGログから特定）
prCreation: "status-success" は「すべてのステータスチェックが success」になるまで PR を作成しない設定だが、以下のタイミング問題が発生していた:

1. Renovate がブランチを作成/更新
2. renovate/stability-days ステータスを green に設定
3. この時点で GitHub Actions CI がトリガーされる（まだ実行中 = pending）
4. Renovate が全体のブランチステータスを確認
5. CI がまだ実行中のため、全体ステータスは pending と評価
6. prCreation: "status-success" により PR 作成がスキップされる

DEBUGログの証拠:
```
Updating renovate/stability-days status check state to green
Setting branch status: "context": "renovate/stability-days", "state": "green"
...
Branch status pending, current sha: 1d9c2632950d3a52ef9d2b07164d66305606f0da
```

## なぜ major 更新は PR が作成されたか
major 更新の packageRule には prCreation 設定がなく、デフォルトの immediate が 適用されるため、ステータスに関係なく即座に PR が作成された。

## 検討した代替案
1. CI 完了後に Renovate を再実行する（workflow_run イベント） → Renovate が新しいブランチを作成 → CI → Renovate → ... の無限ループになる
2. prCreation: "not-pending" を使用 → pending でなくなるまで待つが、同様のタイミング問題が発生する可能性

## 解決策
prCreation: "status-success" をコメントアウトし、デフォルトの immediate に戻す。 PR は即座に作成されるが、automerge は CI が成功した後にのみ実行されるため、
「CI が失敗した更新がマージされる」ことはない。

## 副作用
CI が失敗した PR が作成されるようになる（従来は作成されなかった）。
ただし、automerge はされないため、手動で確認・対応が可能。
また、更新の存在に気づけるというメリットもある。

## その他の変更
- LOG_LEVEL を debug から info に戻す（調査完了のため）